### PR TITLE
Update examples and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1544,6 +1544,9 @@ Contains the total count of how many faxes ended in each result, as well as some
 | **scheduledStartTime** | *DateTime* | *results* | The date and time the fax is scheduled to start. |
 | **dateCallStarted** | *DateTime* | *results* | Date and time the fax started transmitting. |
 | **dateCallEnded** | *DateTime* | *results* | Date and time the fax finished transmitting. |
+| **dateDncrWashed** | *DateTime* | *results* | Date and time the fax number finished washing. |
+| **dncrTransactionId** | *String* | *results* | Transaction ID of washed fax number. |
+| **csi** | *String* | *results* | Caller Subscriber Information of the recepient. |
 
 **FaxError:**
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,12 @@ Your specific faxing requirements will dictate which send request type below sho
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ Your specific faxing requirements will dictate which send request type below sho
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
 	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
-            string base64StringOfFile = Convert.ToBase64String(bytes);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
 	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
@@ -95,9 +96,13 @@ To set-up a fax to have retries a request similar to the following example can b
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -131,9 +136,13 @@ To assign a `Retries` in the sendFaxRequest, the request should be similar to th
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -166,9 +175,13 @@ To set-up a fax to have BusyRetries a request similar to the following example c
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -201,9 +214,13 @@ To assign a `BusyRetries` in the sendFaxRequest, the request should be similar t
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -236,9 +253,13 @@ To assign a fax to have a `Resolution` in the request similar to the following e
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -274,9 +295,13 @@ To assign a `Resolution` in the sendFaxRequest, the request should be similar to
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -312,9 +337,13 @@ To assign a fax to have a `FaxDitheringTechnique` in the request similar to the 
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
             apiFaxDocument.DitheringTechniqueSpecified = true;
             apiFaxDocument.DitheringTechnique = faxDitheringTechnique.DETAILED;
@@ -350,9 +379,13 @@ The Timezone will be used to format the datetime display in the fax header, a re
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -385,9 +418,13 @@ To assign a `TimeZone` in the sendFaxRequest, the request should be similar to t
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -420,9 +457,13 @@ Allows the header format that appears at the top of the transmitted fax to be ch
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -460,9 +501,13 @@ To assign a `HeaderFormat` in the sendFaxRequest, the request should be similar 
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -494,9 +539,13 @@ Assigning a `CLI` in the `apiFaxMessage`, a request similar to the following exa
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -528,9 +577,13 @@ Assigning a `CLI` in the `sendFaxRequest`, a request similar to the following ex
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -562,9 +615,13 @@ To send fax with SendFrom in apiFaxMessage a request similar to the following ex
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -601,9 +658,13 @@ To send fax with SendFrom in sendFaxRequest a request similar to the following e
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -639,9 +700,13 @@ To send fax with DNCR in apiFaxMessage, you need to set "dncrSpecified" to true 
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -679,9 +744,13 @@ To send fax with DNCR in sendFaxRequest, you need to set "dncrSpecified" to true
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -719,9 +788,13 @@ To send fax with FPS in apiFaxMessage, you need to set "fpsSpecified" to true in
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -758,9 +831,13 @@ To send fax with FPS in sendFaxRequest, you need to set "fpsSpecified" to true i
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -797,9 +874,13 @@ To send fax with Smartblock in apiFaxMessage, you need to set "smartblockSpecifi
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -836,9 +917,13 @@ To send fax with Smartblock in sendFaxRequest, you need to set "smartblockSpecif
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -874,9 +959,13 @@ To set a ScheduledStartTime for ApiFaxMessage, a request must similar to the fol
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -909,9 +998,13 @@ To set a ScheduledStartTime for SendFaxRequest, a request must similar to the fo
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -944,9 +1037,13 @@ To set a MustBeSentBeforeDate for ApiFaxMessage, you need to set the value of "M
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -980,9 +1077,13 @@ To set a MustBeSentBeforeDate for SendFaxRequest, you need to set the value of "
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -1017,9 +1118,13 @@ To set a MaxFaxPages for ApiFaxMessage, you need to set the value of "MaxFaxPage
 ```C#
          private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -1053,10 +1158,14 @@ To set a MaxFaxPages for SendFaxRequest, you need to set the value of "MaxFaxPag
 
 ```C#
          private static void sendFaxSample(ApiService apiClient)
-        {
+        { 
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -1090,9 +1199,13 @@ To send faxes to multiple destinations a request similar to the following exampl
 ```C#
         private static void sendFaxSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -1134,10 +1247,13 @@ This method is recommended for broadcasting as it takes advantage of the multipl
 ```C#
 private static void sendFaxSample(ApiService apiClient)
         {
-        
+	    // Converts file to base64 string data.
+            Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             //create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             //create an array of api fax documents.
@@ -1879,10 +1995,14 @@ This function allows you to upload a document and save it under a document refer
 ```c#
 private static void saveFaxDocumentSample(ApiService apiClient)
         {
+	    // Converts file to base64 string data.
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = System.Convert.ToBase64String(bytes);
+	    
             //create a saveFaxDocumentRequest.
             saveFaxDocumentRequest saveFaxDocumentRequest = new saveFaxDocumentRequest();
             saveFaxDocumentRequest.FileName = "test.txt";
-            saveFaxDocumentRequest.FileData = "tiffDataBase64==";
+            saveFaxDocumentRequest.FileData = base64StringOfFile;
             saveFaxDocumentRequest.DocumentRef = "doc-ref-xxx"; //note that documentRef must be unique! TODO: Change this!
 
             //call the saveFaxDocument method.

--- a/fax-api-client-csharp-VS2010-v2.1/fax-api-client-csharp/Program.cs
+++ b/fax-api-client-csharp-VS2010-v2.1/fax-api-client-csharp/Program.cs
@@ -512,7 +512,7 @@ namespace fax_api_client_csharp
         private static string sample_TiffFileData()
         {
             // Converts file to base64 string data.
-	        Byte[] bytes = File.ReadAllBytes(@"..\..\sampleTiffBase64.txt");
+	    Byte[] bytes = File.ReadAllBytes(@"..\..\sampleTiffBase64.txt");
             string base64StringOfFile = Convert.ToBase64String(bytes);
            
             return base64StringOfFile;
@@ -521,7 +521,7 @@ namespace fax_api_client_csharp
         private static string sample_StampData()
         {
             // Converts file to base64 string data.
-	        Byte[] bytes = File.ReadAllBytes(@"..\..\sampleTiffBase64.txt");
+	    Byte[] bytes = File.ReadAllBytes(@"..\..\sampleTiffBase64.txt");
             string base64StringOfFile = Convert.ToBase64String(bytes);
             
             return base64StringOfFile;
@@ -530,7 +530,7 @@ namespace fax_api_client_csharp
         private static string sample_DocxFileData() 
         {
             // Converts file to base64 string data.
-	        Byte[] bytes = File.ReadAllBytes(@"..\..\sample.docx");
+	    Byte[] bytes = File.ReadAllBytes(@"..\..\sample.docx");
             string base64StringOfFile = Convert.ToBase64String(bytes);
             
             return base64StringOfFile;

--- a/fax-api-client-csharp-VS2010-v2.1/fax-api-client-csharp/Program.cs
+++ b/fax-api-client-csharp-VS2010-v2.1/fax-api-client-csharp/Program.cs
@@ -46,9 +46,13 @@ namespace fax_api_client_csharp
 
         private static void sendFaxSample(ApiService apiClient)
         {
+            // Converts file to base64 string data.
+	        Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+            string base64StringOfFile = Convert.ToBase64String(bytes);
+            
             // create a new fax document.
             apiFaxDocument apiFaxDocument = new apiFaxDocument();
-            apiFaxDocument.FileData = "VGhpcyBpcyBhIGZheA==";
+            apiFaxDocument.FileData = base64StringOfFile;
             apiFaxDocument.FileName = "test.txt";
 
             // create an array of api fax documents.
@@ -507,26 +511,29 @@ namespace fax_api_client_csharp
 
         private static string sample_TiffFileData()
         {
-            //note: We are reading from a text file since the base64 equivalent is too long.
-            string text = System.IO.File.ReadAllText(@"..\..\sampleTiffBase64.txt");
-            
-            return text;
+            // Converts file to base64 string data.
+	        Byte[] bytes = File.ReadAllBytes(@"..\..\sampleTiffBase64.txt");
+            string base64StringOfFile = Convert.ToBase64String(bytes);
+           
+            return base64StringOfFile;
         }
 
         private static string sample_StampData()
         {
-            //note: We are reading from a text file since the base64 equivalent is too long.
-            string text = System.IO.File.ReadAllText(@"..\..\sampleStampBase64.txt");
-
-            return text;
+            // Converts file to base64 string data.
+	        Byte[] bytes = File.ReadAllBytes(@"..\..\sampleTiffBase64.txt");
+            string base64StringOfFile = Convert.ToBase64String(bytes);
+            
+            return base64StringOfFile;
         }
 
         private static string sample_DocxFileData() 
         {
-            //note: We are reading from a text file since the base64 equivalent is too long.
-            string text = System.IO.File.ReadAllText(@"..\..\sampleDocxBase64.txt");
-
-            return text; 
+            // Converts file to base64 string data.
+	        Byte[] bytes = File.ReadAllBytes(@"..\..\sample.docx");
+            string base64StringOfFile = Convert.ToBase64String(bytes);
+            
+            return base64StringOfFile;
         }
     }
 }

--- a/fax-api-client-csharp-VS2010-v2.1/fax-api-client-csharp/Program.cs
+++ b/fax-api-client-csharp-VS2010-v2.1/fax-api-client-csharp/Program.cs
@@ -47,7 +47,7 @@ namespace fax_api_client_csharp
         private static void sendFaxSample(ApiService apiClient)
         {
             // Converts file to base64 string data.
-	        Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
+	    Byte[] bytes = File.ReadAllBytes(FILE_LOCATION);
             string base64StringOfFile = Convert.ToBase64String(bytes);
             
             // create a new fax document.


### PR DESCRIPTION
Hi guys,

I added codes that convert a file to base64 string data for all API request examples.

This base64 string is used as the value of the `FileData` of the FaxDocument.

Thanks,
Michael